### PR TITLE
fix: use correct API endpoint for main resource page sync

### DIFF
--- a/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
+++ b/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
@@ -54,11 +54,7 @@ abstract class PageSyncTask : DefaultTask() {
         val isMainPage = page.name == ProjectPageContainerImpl.RESOURCE_PAGE_ID
         // `editmain` edits the project's main/home page (takes {"content": ...})
         // `edit` edits sub-pages (takes {"path": name, "content": ...})
-        val methodEndpoint = if (isMainPage) {
-            "pages/editmain/${this.id.get()}"
-        } else {
-            "pages/edit/${this.id.get()}"
-        }
+        val methodEndpoint = if (isMainPage) "pages/editmain/${this.id.get()}" else "pages/edit/${this.id.get()}"
         send(this.auth.get(), this.apiEndpoint.get(), methodEndpoint, this.apiKey.get(), ::HttpPatch) { entity ->
             val body = JsonObject()
             body.addProperty("content", content)

--- a/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
+++ b/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
@@ -61,11 +61,9 @@ abstract class PageSyncTask : DefaultTask() {
         }
         send(this.auth.get(), this.apiEndpoint.get(), methodEndpoint, this.apiKey.get(), ::HttpPatch) { entity ->
             val body = JsonObject()
-            if (isMainPage) {
-                body.addProperty("content", content)
-            } else {
+            body.addProperty("content", content)
+            if (!isMainPage) {
                 body.addProperty("path", page.name)
-                body.addProperty("content", content)
             }
             entity.addBody(body)
         }

--- a/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
+++ b/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/PageSyncTask.kt
@@ -51,11 +51,22 @@ abstract class PageSyncTask : DefaultTask() {
     fun run() {
         val page = this.page.get()
         val content = page.content.get()
-        val methodEndpoint = "pages/edit/${this.id.get()}"
+        val isMainPage = page.name == ProjectPageContainerImpl.RESOURCE_PAGE_ID
+        // `editmain` edits the project's main/home page (takes {"content": ...})
+        // `edit` edits sub-pages (takes {"path": name, "content": ...})
+        val methodEndpoint = if (isMainPage) {
+            "pages/editmain/${this.id.get()}"
+        } else {
+            "pages/edit/${this.id.get()}"
+        }
         send(this.auth.get(), this.apiEndpoint.get(), methodEndpoint, this.apiKey.get(), ::HttpPatch) { entity ->
             val body = JsonObject()
-            body.addProperty("path", page.name.takeIf { it != ProjectPageContainerImpl.RESOURCE_PAGE_ID } ?: "")
-            body.addProperty("content", content)
+            if (isMainPage) {
+                body.addProperty("content", content)
+            } else {
+                body.addProperty("path", page.name)
+                body.addProperty("content", content)
+            }
             entity.addBody(body)
         }
     }

--- a/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/internal/HangarRequest.kt
+++ b/plugin/src/main/kotlin/io/papermc/hangarpublishplugin/internal/HangarRequest.kt
@@ -22,6 +22,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.core5.http.ClassicHttpRequest
 import org.apache.hc.core5.http.HttpHeaders
 import org.apache.hc.core5.http.io.entity.StringEntity
+import org.gradle.api.GradleException
 import org.gradle.api.logging.Logging
 import java.nio.charset.StandardCharsets
 
@@ -44,7 +45,9 @@ fun <T : ClassicHttpRequest> send(
         entityDecorator(entity)
         client.execute(entity) { response ->
             if (response.code != 200) {
-                logger.error("Error using endpoint '{}', returned {}: {}", endpoint, response.code, ErrorResponseParser.parse(response))
+                val errorBody = ErrorResponseParser.parse(response)
+                logger.error("Error using endpoint '{}', returned {}: {}", endpoint, response.code, errorBody)
+                throw GradleException("Hangar API request to '$endpoint' failed with status ${response.code}: $errorBody")
             }
         }
     }


### PR DESCRIPTION
PageSyncTask was sending PATCH requests to `/api/v1/pages/edit/{project}` (the sub-page endpoint) when syncing the main resource page. The Hangar API provides two distinct endpoints:

- `/api/v1/pages/editmain/{project}` for the main/home page (takes `{"content": "..."}`)
- `/api/v1/pages/edit/{project}` for named sub-pages (takes `{"path": "...", "content": "..."}`)

Now checks whether the page is the main resource page (`page.name == RESOURCE_PAGE_ID`) and uses the correct endpoint and request body format accordingly.
